### PR TITLE
Add init_file(file, conn) callback

### DIFF
--- a/lib/tus/controller.ex
+++ b/lib/tus/controller.ex
@@ -23,6 +23,10 @@ defmodule Tus.Controller do
         call_method(conn, config |> Map.put(:uid, uid))
       end
 
+      def init_file(file, _conn) do
+        file
+      end
+
       def on_begin_upload(_file) do
         :ok
       end
@@ -30,7 +34,7 @@ defmodule Tus.Controller do
       def on_complete_upload(_file) do
       end
 
-      defoverridable on_begin_upload: 1, on_complete_upload: 1
+      defoverridable on_begin_upload: 1, on_complete_upload: 1, init_file: 2
 
       defp call_method(conn, config \\ %{}) do
         config = update_config(conn, config)
@@ -51,6 +55,7 @@ defmodule Tus.Controller do
           |> Map.put(:version, get_version(conn))
           |> Map.put(:on_begin_upload, &on_begin_upload/1)
           |> Map.put(:on_complete_upload, &on_complete_upload/1)
+          |> Map.put(:init_file, &init_file/2)
 
         Map.merge(app_env, config)
       end

--- a/lib/tus/post.ex
+++ b/lib/tus/post.ex
@@ -6,6 +6,7 @@ defmodule Tus.Post do
 
   def post(conn, %{version: version, max_size: max_size} = config) when version == "1.0.0" do
     with {:ok, file} <- build_file(conn),
+         file <- config.init_file.(file, conn),
          :ok <- file_size_ok?(conn, file, max_size),
          {:ok, file} <- create_file(file, config),
          :ok <- cache_file(file, config),

--- a/test/post_test.exs
+++ b/test/post_test.exs
@@ -156,4 +156,21 @@ defmodule Tus.PostTest do
 
     File.rm_rf(config.base_path |> Path.expand())
   end
+
+  test "init_file called with conn", context do
+    config = context[:config]
+    TestController.post(
+      test_conn(:post, %Plug.Conn{
+        req_headers: [
+          {"tus-resumable", Tus.latest_version()},
+          {"upload-length", "10"}
+        ]
+      })
+    )
+
+    # https://dockyard.com/blog/2016/03/24/testing-function-delegation-in-elixir-without-stubbing
+    assert_receive {:init_file, %Plug.Conn{}}
+
+    File.rm_rf(config.base_path |> Path.expand())
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,11 @@
 defmodule Tus.TestController do
   use Tus.Controller
 
+  def init_file(file, conn) do
+    send self(), {:init_file, conn}
+    file
+  end
+
   def on_begin_upload(_file) do
     send self(), :on_begin_upload_called
     :ok


### PR DESCRIPTION
To use Tus with authentication, we need a place to read Conn data (for example to check current user) and to add user_id to the Tus.File struct. 

This PR proposes a callback: `init_file(file, conn) -> file`
