### PR TITLE
Fix initialization of File metadata in `Tus.Post.build_file`

### DIFF
--- a/lib/tus/post.ex
+++ b/lib/tus/post.ex
@@ -36,7 +36,7 @@ defmodule Tus.Post do
       if metadata_src do
         parse_metadata(metadata_src)
       else
-        nil
+        %{}
       end
 
     file = %Tus.File{


### PR DESCRIPTION
`Tus.File` metadata field is initialized to `%{}` in an empty struct, however, when no metadata headers are passed onto `post` controller, `Tus.Post.post` will override the metadata field with `nil`. I believe this is a bug and inconsistency – changing this behaviour to leave an empty map instead.
