### PR TITLE
allow upload metadata header with empty value

### DIFF
--- a/lib/tus/post.ex
+++ b/lib/tus/post.ex
@@ -66,8 +66,10 @@ defmodule Tus.Post do
   end
 
   defp split_metadata(kv) do
-    [key, value] = String.split(kv, ~r/\s+/, parts: 2)
-    {key, Base.decode64!(value)}
+    case String.split(kv, ~r/\s+/, parts: 2) do
+      [key] -> {key, nil}
+      [key, value] -> {key, Base.decode64!(value)}
+    end
   end
 
   defp get_size(conn) do

--- a/test/post_test.exs
+++ b/test/post_test.exs
@@ -153,6 +153,28 @@ defmodule Tus.PostTest do
     assert Tus.Post.parse_metadata(metadata_src) == expected
   end
 
+  test "parse metadata with key followed by a space and empty value" do
+    metadata_src = "filename ,username YnJhaW4="
+
+    expected = [
+      {"filename", nil},
+      {"username", "brain"}
+    ]
+
+    assert Tus.Post.parse_metadata(metadata_src) == expected
+  end
+
+  test "parse metadata with only key" do
+    metadata_src = "filename,username YnJhaW4="
+
+    expected = [
+      {"filename", nil},
+      {"username", "brain"}
+    ]
+
+    assert Tus.Post.parse_metadata(metadata_src) == expected
+  end
+
   test "create a new upload with metadata", context do
     config = context[:config]
     metadata_src = "filename d29ybGRfZG9taW5hdGlvbl9wbGFuLnBkZg==,username YnJhaW4="


### PR DESCRIPTION
According to the spec,  the value of a key-value pair in upload-metadata header, may be empty